### PR TITLE
feature#6(redefinir-senha): implementa fluxo de redefinição de senha na API

### DIFF
--- a/backend/src/main/java/com/ufrn/pertindetu/base/utils/email/EmailService.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/base/utils/email/EmailService.java
@@ -1,0 +1,18 @@
+package com.ufrn.pertindetu.base.utils.email;
+
+import com.ufrn.pertindetu.user.model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
+
+    public void sendPasswordReset(User user, String resetUrl) {
+        // In development we just log the reset URL. Replace with real email sending if needed.
+        logger.info("Password reset requested for user {}. Reset URL: {}", user.getEmail(), resetUrl);
+    }
+}
+

--- a/backend/src/main/java/com/ufrn/pertindetu/user/controller/PasswordResetController.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/user/controller/PasswordResetController.java
@@ -1,0 +1,40 @@
+package com.ufrn.pertindetu.user.controller;
+
+import com.ufrn.pertindetu.base.dto.ApiResponseDTO;
+import com.ufrn.pertindetu.base.dto.ErrorDTO;
+import com.ufrn.pertindetu.user.dto.PasswordResetConfirmDTO;
+import com.ufrn.pertindetu.user.dto.PasswordResetRequestDTO;
+import com.ufrn.pertindetu.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+public class PasswordResetController {
+
+    private final UserService userService;
+
+    public PasswordResetController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponseDTO<Object>> requestReset(@Valid @RequestBody PasswordResetRequestDTO dto, HttpServletRequest request) {
+        // Build a base URL for the frontend from request (could be configured instead)
+        String baseUrl = request.getHeader("X-Frontend-Base") != null ? request.getHeader("X-Frontend-Base") : request.getRequestURL().toString();
+        userService.initiatePasswordReset(dto.getEmail(), baseUrl);
+        return ResponseEntity.ok(new ApiResponseDTO<>(true, null, null));
+    }
+
+    @PostMapping("/reset-password/confirm")
+    public ResponseEntity<ApiResponseDTO<Object>> confirmReset(@Valid @RequestBody PasswordResetConfirmDTO dto) {
+        userService.confirmPasswordReset(dto.getToken(), dto.getNewPassword());
+        return ResponseEntity.ok(new ApiResponseDTO<>(true, null, null));
+    }
+}
+

--- a/backend/src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetConfirmDTO.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetConfirmDTO.java
@@ -1,0 +1,25 @@
+package com.ufrn.pertindetu.user.dto;
+
+import com.ufrn.pertindetu.base.dto.EntityDTO;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class PasswordResetConfirmDTO implements EntityDTO {
+
+    @NotBlank
+    private String token;
+
+    @NotBlank
+    @Size(min = 8, message = "Password must have at least 8 characters")
+    private String newPassword;
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
+
+    @Override
+    public EntityDTO toResponse() { return this; }
+}
+

--- a/backend/src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetRequestDTO.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetRequestDTO.java
@@ -1,0 +1,19 @@
+package com.ufrn.pertindetu.user.dto;
+
+import com.ufrn.pertindetu.base.dto.EntityDTO;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class PasswordResetRequestDTO implements EntityDTO {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    @Override
+    public EntityDTO toResponse() { return this; }
+}
+

--- a/backend/src/main/java/com/ufrn/pertindetu/user/model/User.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/user/model/User.java
@@ -39,6 +39,12 @@ public class User extends BaseEntity {
     @Column(name = "phone", length = 20)
     private String phone;
 
+    @Column(name = "reset_token", length = 255)
+    private String resetToken;
+
+    @Column(name = "reset_token_expiry")
+    private java.time.ZonedDateTime resetTokenExpiry;
+
     @Override
     public Long getId() { return id; }
 
@@ -59,4 +65,10 @@ public class User extends BaseEntity {
 
     public String getPhone() { return phone; }
     public void setPhone(String phone) { this.phone = phone; }
+
+    public String getResetToken() { return resetToken; }
+    public void setResetToken(String resetToken) { this.resetToken = resetToken; }
+
+    public java.time.ZonedDateTime getResetTokenExpiry() { return resetTokenExpiry; }
+    public void setResetTokenExpiry(java.time.ZonedDateTime resetTokenExpiry) { this.resetTokenExpiry = resetTokenExpiry; }
 }

--- a/backend/src/main/java/com/ufrn/pertindetu/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/user/repository/UserRepository.java
@@ -11,5 +11,9 @@ public interface UserRepository extends GenericRepository<User> {
 
     Optional<User> findByEmailAndActiveTrue(String email);
 
+    Optional<User> findByResetToken(String resetToken);
+
+    Optional<User> findByEmail(String email);
+
     boolean existsByEmailAndActiveTrue(String email);
 }

--- a/backend/src/main/java/com/ufrn/pertindetu/user/service/UserService.java
+++ b/backend/src/main/java/com/ufrn/pertindetu/user/service/UserService.java
@@ -19,16 +19,52 @@ public class UserService implements GenericService<User, UserDTO> {
     private final UserRepository userRepository;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
+    private final com.ufrn.pertindetu.base.utils.email.EmailService emailService;
 
-    public UserService(UserRepository userRepository, UserMapper userMapper) {
+    public UserService(UserRepository userRepository, UserMapper userMapper, com.ufrn.pertindetu.base.utils.email.EmailService emailService) {
         this.userRepository = userRepository;
         this.userMapper = userMapper;
         this.passwordEncoder = new BCryptPasswordEncoder();
+        this.emailService = emailService;
     }
 
     @Override
     public GenericRepository<User> getRepository() {
         return userRepository;
+    }
+
+    public void initiatePasswordReset(String email, String frontendBaseUrl) {
+        var userOpt = userRepository.findByEmailAndActiveTrue(email);
+        if (userOpt.isEmpty()) {
+            // For security, do not reveal whether the email exists. Just return silently.
+            return;
+        }
+
+        var user = userOpt.get();
+        var token = java.util.UUID.randomUUID().toString();
+        user.setResetToken(token);
+        user.setResetTokenExpiry(java.time.ZonedDateTime.now().plusHours(1));
+        userRepository.save(user);
+
+        String resetUrl = frontendBaseUrl + "/reset-password?token=" + token;
+        emailService.sendPasswordReset(user, resetUrl);
+    }
+
+    public void confirmPasswordReset(String token, String newPassword) {
+        var userOpt = userRepository.findByResetToken(token);
+        if (userOpt.isEmpty()) {
+            throw new BusinessException("Invalid password reset token.", HttpStatus.BAD_REQUEST);
+        }
+
+        var user = userOpt.get();
+        if (user.getResetTokenExpiry() == null || user.getResetTokenExpiry().isBefore(java.time.ZonedDateTime.now())) {
+            throw new BusinessException("Password reset token has expired.", HttpStatus.BAD_REQUEST);
+        }
+
+        user.setPasswordHash(passwordEncoder.encode(newPassword));
+        user.setResetToken(null);
+        user.setResetTokenExpiry(null);
+        userRepository.save(user);
     }
 
     @Override

--- a/backend/src/main/resources/db/migration/V2__add_password_reset_fields.sql
+++ b/backend/src/main/resources/db/migration/V2__add_password_reset_fields.sql
@@ -1,0 +1,7 @@
+-- Add columns to store password reset token and its expiry
+ALTER TABLE users
+    ADD COLUMN reset_token VARCHAR(255);
+
+ALTER TABLE users
+    ADD COLUMN reset_token_expiry TIMESTAMP;
+


### PR DESCRIPTION
# Resumo da feature: Reset de senha

Este PR implementa um fluxo mínimo e seguro de redefinição de senha no back-end.

Objetivo: expor endpoint para solicitar reset e outro para confirmar a nova senha em:

- POST /reset-password
- POST /reset-password/confirm

Resumo das alterações realizadas

- Migração de banco de dados (Flyway):
  - `src/main/resources/db/migration/V2__add_password_reset_fields.sql`
    - Adiciona as colunas `reset_token VARCHAR(255)` e `reset_token_expiry TIMESTAMP` na tabela `users`.

- Model / Repository:
  - `src/main/java/com/ufrn/pertindetu/user/model/User.java`
    - Adicionados campos `resetToken` (String) e `resetTokenExpiry` (ZonedDateTime) com getters/setters.
  - `src/main/java/com/ufrn/pertindetu/user/repository/UserRepository.java`
    - Adicionados métodos `findByResetToken(String resetToken)` e `findByEmail(String email)`.

- DTOs:
  - `src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetRequestDTO.java` (email)
  - `src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetConfirmDTO.java` (token, newPassword)

- Serviço de e-mail (placeholder):
  - `src/main/java/com/ufrn/pertindetu/base/utils/email/EmailService.java`
    - Serviço simples que faz log da URL de reset (substituir por envio real quando necessário).

- Lógica de negócio:
  - `src/main/java/com/ufrn/pertindetu/user/service/UserService.java`
    - `initiatePasswordReset(String email, String frontendBaseUrl)`
      - Gera token (UUID), define expiry = agora + 1 hora, salva no usuário e chama `EmailService`.
      - Não revela se o e-mail existe (retorna silenciosamente em caso ausente) para evitar enumeração.
    - `confirmPasswordReset(String token, String newPassword)`
      - Valida token (presença e expiry), atualiza `passwordHash` com BCrypt, limpa token/expiry.

- Controller (endpoints):
  - `src/main/java/com/ufrn/pertindetu/user/controller/PasswordResetController.java`
    - POST `/reset-password` — recebe `{ "email": "..." }` e inicia o fluxo.
    - POST `/reset-password/confirm` — recebe `{ "token": "...", "newPassword": "..." }` e aplica a troca.

Comportamento e observações de segurança

- Token: atualmente é um UUID gerado por `UUID.randomUUID()` e armazenado em texto no DB.
  - Válido por 1 hora.
  - Recomendação: em produção é preferível armazenar apenas o hash do token (ex.: SHA-256) e enviar o token em claro por e-mail.

- E-mail: a implementação atual apenas registra o link no log (desenvolvimento). Para envio real,
  adicione `spring-boot-starter-mail` e configure `spring.mail.*` no `application.properties` ou integre um provedor (SendGrid, etc.).

- Proteção contra enumeração: o endpoint de solicitação não informa se o e-mail existe.

Exemplos de uso

- Solicitar reset (manual):

```bash
curl -X POST http://localhost:8080/reset-password \
  -H "Content-Type: application/json" \
  -d '{"email":"user@example.com"}'
```

Você pode fornecer um header para controlar a URL base do frontend usada no link de reset:

```bash
curl -X POST http://localhost:8080/reset-password \
  -H "Content-Type: application/json" \
  -H "X-Frontend-Base: https://app.example.com" \
  -d '{"email":"user@example.com"}'
```

- Confirmar reset:

```bash
curl -X POST http://localhost:8080/reset-password/confirm \
  -H "Content-Type: application/json" \
  -d '{"token":"<TOKEN_DO_LOG>", "newPassword":"NovaSenha123"}'
```

Migração / build / run

- O projeto usa Flyway; ao iniciar a aplicação as migrações são aplicadas automaticamente.
- Se preferir rodar os testes/compilar:

```bash
cd backend
# se tiver mvnw
./mvnw test
# ou usando mvn local
mvn -f pom.xml test
```

Nota: no meu ambiente de execução aqui encontrei falta do arquivo do wrapper Maven (`.mvn/wrapper/maven-wrapper.properties`) — isso não impede o PR, apenas pode exigir que o revisor rode com `mvn` local se não houver wrapper no repositório.

Testes recomendados

- Unitários
  - `PasswordResetServiceTest` cobrindo: geração de token, persistência, expirations, confirmação com senha válida e inválida.
- Integração
  - `PasswordResetControllerIT` cobrindo endpoints, mock do `EmailService` e fluxo end-to-end (incluindo persistência em banco de teste).

Melhorias futuras (opcionais)

- Trocar armazenamento do token por hash (SHA-256) para maior segurança.
- Usar tabela dedicada `password_reset_tokens` para permitir histórico, single-use e auditoria.
- Implementar envio real de e-mail (SMTP / SendGrid) e templates i18n.
- Adicionar limites de taxa (rate limiting) per-email/IP para evitar abuso.

Arquivos alterados (rápida listagem)

```
src/main/resources/db/migration/V2__add_password_reset_fields.sql
src/main/java/com/ufrn/pertindetu/user/model/User.java
src/main/java/com/ufrn/pertindetu/user/repository/UserRepository.java
src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetRequestDTO.java
src/main/java/com/ufrn/pertindetu/user/dto/PasswordResetConfirmDTO.java
src/main/java/com/ufrn/pertindetu/base/utils/email/EmailService.java
src/main/java/com/ufrn/pertindetu/user/service/UserService.java
src/main/java/com/ufrn/pertindetu/user/controller/PasswordResetController.java
```